### PR TITLE
WIP: Prelude changes to allow windows RE to work

### DIFF
--- a/prelude/cxx/tools/BUCK.v2
+++ b/prelude/cxx/tools/BUCK.v2
@@ -22,15 +22,27 @@ prelude.command_alias(
     visibility = ["PUBLIC"],
 )
 
+prelude.export_file(
+    name = "make_comp_db.py",
+    src = "make_comp_db.py",
+    visibility = ["PUBLIC"],
+)
+
 prelude.python_bootstrap_binary(
     name = "make_comp_db",
-    main = "make_comp_db.py",
+    main = ":make_comp_db.py",
+    visibility = ["PUBLIC"],
+)
+
+prelude.export_file(
+    name = "dep_file_processor.py",
+    src = "dep_file_processor.py",
     visibility = ["PUBLIC"],
 )
 
 prelude.python_bootstrap_binary(
     name = "dep_file_processor",
-    main = "dep_file_processor.py",
+    main = ":dep_file_processor.py",
     visibility = ["PUBLIC"],
     deps = [
         ":dep_file_processors",
@@ -48,9 +60,15 @@ prelude.python_bootstrap_library(
     visibility = ["PUBLIC"],
 )
 
+prelude.export_file(
+    name = "linker_wrapper.py",
+    src = "linker_wrapper.py",
+    visibility = ["PUBLIC"],
+)
+
 prelude.python_bootstrap_binary(
     name = "linker_wrapper",
-    main = "linker_wrapper.py",
+    main = ":linker_wrapper.py",
     visibility = ["PUBLIC"],
 )
 

--- a/prelude/cxx/tools/BUCK.v2
+++ b/prelude/cxx/tools/BUCK.v2
@@ -22,27 +22,15 @@ prelude.command_alias(
     visibility = ["PUBLIC"],
 )
 
-prelude.export_file(
-    name = "make_comp_db.py",
-    src = "make_comp_db.py",
-    visibility = ["PUBLIC"],
-)
-
 prelude.python_bootstrap_binary(
     name = "make_comp_db",
-    main = ":make_comp_db.py",
-    visibility = ["PUBLIC"],
-)
-
-prelude.export_file(
-    name = "dep_file_processor.py",
-    src = "dep_file_processor.py",
+    main = "make_comp_db.py",
     visibility = ["PUBLIC"],
 )
 
 prelude.python_bootstrap_binary(
     name = "dep_file_processor",
-    main = ":dep_file_processor.py",
+    main = "dep_file_processor.py",
     visibility = ["PUBLIC"],
     deps = [
         ":dep_file_processors",
@@ -60,15 +48,9 @@ prelude.python_bootstrap_library(
     visibility = ["PUBLIC"],
 )
 
-prelude.export_file(
-    name = "linker_wrapper.py",
-    src = "linker_wrapper.py",
-    visibility = ["PUBLIC"],
-)
-
 prelude.python_bootstrap_binary(
     name = "linker_wrapper",
-    main = ":linker_wrapper.py",
+    main = "linker_wrapper.py",
     visibility = ["PUBLIC"],
 )
 

--- a/prelude/decls/shell_rules.bzl
+++ b/prelude/decls/shell_rules.bzl
@@ -81,6 +81,10 @@ sh_binary = prelude_rule(
                   appending one itself if necessary. Setting this to False prevents that behavior and makes the caller
                   responsible for ensuring an existing appropriate extension.
             """),
+            "copy_resources": attrs.bool(default = False, doc = """
+                By default, sh_binary attempts to use symbolic links for the resources. This can be changed so,
+                that copies are made instead.
+            """),
             "contacts": attrs.list(attrs.string(), default = []),
             "default_host_platform": attrs.option(attrs.configuration_label(), default = None),
             "deps": attrs.list(attrs.dep(), default = []),

--- a/prelude/python_bootstrap/python_bootstrap.bzl
+++ b/prelude/python_bootstrap/python_bootstrap.bzl
@@ -27,6 +27,7 @@ def python_bootstrap_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     they can and can't do. In particular, bootstrap binaries can only depend on
     bootstrap libraries and can only consist of a single file.
     """
+    copy_deps = ctx.attrs.copy_deps
     run_tree_inputs = {}
     run_tree_recorded_deps = {}  # For a better error message when files collide
     for dep in ctx.attrs.deps:
@@ -38,8 +39,7 @@ def python_bootstrap_binary_impl(ctx: AnalysisContext) -> list[Provider]:
             run_tree_inputs[src.short_path] = src
             run_tree_recorded_deps[src.short_path] = dep
 
-    copy = True
-    if copy:
+    if copy_deps:
         run_tree = ctx.actions.copied_dir("__%s__" % ctx.attrs.name, run_tree_inputs)
     else:
         run_tree = ctx.actions.symlinked_dir("__%s__" % ctx.attrs.name, run_tree_inputs)
@@ -48,9 +48,9 @@ def python_bootstrap_binary_impl(ctx: AnalysisContext) -> list[Provider]:
 
     interpreter = ctx.attrs._python_bootstrap_toolchain[PythonBootstrapToolchainInfo].interpreter
 
-    if ctx.attrs._win_python_copied_wrapper != None and ctx.attrs._win_python_symlinked_wrapper != None:
+    if ctx.attrs._win_python_wrapper != None:
         run_args = cmd_args(
-            ctx.attrs._win_python_copied_wrapper[RunInfo] if copy else ctx.attrs._win_python_symlinked_wrapper[RunInfo],
+            ctx.attrs._win_python_wrapper[RunInfo],
             run_tree,
             interpreter,
             output,

--- a/prelude/python_bootstrap/python_bootstrap.bzl
+++ b/prelude/python_bootstrap/python_bootstrap.bzl
@@ -38,14 +38,19 @@ def python_bootstrap_binary_impl(ctx: AnalysisContext) -> list[Provider]:
             run_tree_inputs[src.short_path] = src
             run_tree_recorded_deps[src.short_path] = dep
 
-    run_tree = ctx.actions.symlinked_dir("__%s__" % ctx.attrs.name, run_tree_inputs)
+    copy = True
+    if copy:
+        run_tree = ctx.actions.copied_dir("__%s__" % ctx.attrs.name, run_tree_inputs)
+    else:
+        run_tree = ctx.actions.symlinked_dir("__%s__" % ctx.attrs.name, run_tree_inputs)
+
     output = ctx.actions.copy_file(ctx.attrs.main.short_path, ctx.attrs.main)
 
     interpreter = ctx.attrs._python_bootstrap_toolchain[PythonBootstrapToolchainInfo].interpreter
 
-    if ctx.attrs._win_python_wrapper != None:
+    if ctx.attrs._win_python_copied_wrapper != None and ctx.attrs._win_python_symlinked_wrapper != None:
         run_args = cmd_args(
-            ctx.attrs._win_python_wrapper[RunInfo],
+            ctx.attrs._win_python_copied_wrapper[RunInfo] if copy else ctx.attrs._win_python_symlinked_wrapper[RunInfo],
             run_tree,
             interpreter,
             output,

--- a/prelude/python_bootstrap/tools/BUCK.v2
+++ b/prelude/python_bootstrap/tools/BUCK.v2
@@ -7,8 +7,17 @@ source_listing()
 prelude = native
 
 prelude.sh_binary(
-    name = "win_python_wrapper",
+    name = "win_python_copied_wrapper",
     main = "win_python_wrapper.bat",
+    copy_resources = True,
+    target_compatible_with = ["config//os:windows"],
+    visibility = ["PUBLIC"],
+)
+
+prelude.sh_binary(
+    name = "win_python_symlinked_wrapper",
+    main = "win_python_wrapper.bat",
+    copy_resources = False,
     target_compatible_with = ["config//os:windows"],
     visibility = ["PUBLIC"],
 )

--- a/prelude/python_bootstrap/tools/BUCK.v2
+++ b/prelude/python_bootstrap/tools/BUCK.v2
@@ -6,9 +6,16 @@ source_listing()
 
 prelude = native
 
+prelude.export_file(
+    name = "win_python_wrapper.bat",
+    src = "win_python_wrapper.bat",
+    target_compatible_with = ["config//os:windows"],
+    visibility = ["PUBLIC"],
+)
+
 prelude.sh_binary(
     name = "win_python_wrapper",
-    main = "win_python_wrapper.bat",
+    main = ":win_python_wrapper.bat",
     target_compatible_with = ["config//os:windows"],
     visibility = ["PUBLIC"],
 )

--- a/prelude/python_bootstrap/tools/BUCK.v2
+++ b/prelude/python_bootstrap/tools/BUCK.v2
@@ -7,17 +7,8 @@ source_listing()
 prelude = native
 
 prelude.sh_binary(
-    name = "win_python_copied_wrapper",
+    name = "win_python_wrapper",
     main = "win_python_wrapper.bat",
-    copy_resources = True,
-    target_compatible_with = ["config//os:windows"],
-    visibility = ["PUBLIC"],
-)
-
-prelude.sh_binary(
-    name = "win_python_symlinked_wrapper",
-    main = "win_python_wrapper.bat",
-    copy_resources = False,
     target_compatible_with = ["config//os:windows"],
     visibility = ["PUBLIC"],
 )

--- a/prelude/python_bootstrap/tools/BUCK.v2
+++ b/prelude/python_bootstrap/tools/BUCK.v2
@@ -6,16 +6,10 @@ source_listing()
 
 prelude = native
 
-prelude.export_file(
-    name = "win_python_wrapper.bat",
-    src = "win_python_wrapper.bat",
-    target_compatible_with = ["config//os:windows"],
-    visibility = ["PUBLIC"],
-)
-
 prelude.sh_binary(
     name = "win_python_wrapper",
-    main = ":win_python_wrapper.bat",
+    main = "win_python_wrapper.bat",
+    copy_resources = True,
     target_compatible_with = ["config//os:windows"],
     visibility = ["PUBLIC"],
 )

--- a/prelude/rules_impl.bzl
+++ b/prelude/rules_impl.bzl
@@ -595,12 +595,21 @@ inlined_extra_attributes = {
         "main": attrs.source(),
         "_exec_os_type": buck.exec_os_type_arg(),
         "_python_bootstrap_toolchain": toolchains_common.python_bootstrap(),
-        "_win_python_wrapper": attrs.default_only(
+        "_win_python_copied_wrapper": attrs.default_only(
             attrs.option(
                 attrs.dep(),
                 default = select({
                     "DEFAULT": None,
-                    "config//os:windows": "prelude//python_bootstrap/tools:win_python_wrapper",
+                    "config//os:windows": "prelude//python_bootstrap/tools:win_python_copied_wrapper",
+                }),
+            )
+        ),
+        "_win_python_symlinked_wrapper": attrs.default_only(
+            attrs.option(
+                attrs.dep(),
+                default = select({
+                    "DEFAULT": None,
+                    "config//os:windows": "prelude//python_bootstrap/tools:win_python_symlinked_wrapper",
                 }),
             ),
         ),

--- a/prelude/rules_impl.bzl
+++ b/prelude/rules_impl.bzl
@@ -593,23 +593,15 @@ inlined_extra_attributes = {
     "python_bootstrap_binary": {
         "deps": attrs.list(attrs.dep(providers = [PythonBootstrapSources]), default = []),
         "main": attrs.source(),
+        "copy_deps": attrs.bool(default = False),
         "_exec_os_type": buck.exec_os_type_arg(),
         "_python_bootstrap_toolchain": toolchains_common.python_bootstrap(),
-        "_win_python_copied_wrapper": attrs.default_only(
+        "_win_python_wrapper": attrs.default_only(
             attrs.option(
                 attrs.dep(),
                 default = select({
                     "DEFAULT": None,
-                    "config//os:windows": "prelude//python_bootstrap/tools:win_python_copied_wrapper",
-                }),
-            )
-        ),
-        "_win_python_symlinked_wrapper": attrs.default_only(
-            attrs.option(
-                attrs.dep(),
-                default = select({
-                    "DEFAULT": None,
-                    "config//os:windows": "prelude//python_bootstrap/tools:win_python_symlinked_wrapper",
+                    "config//os:windows": "prelude//python_bootstrap/tools:win_python_wrapper",
                 }),
             ),
         ),

--- a/prelude/rules_impl.bzl
+++ b/prelude/rules_impl.bzl
@@ -593,7 +593,7 @@ inlined_extra_attributes = {
     "python_bootstrap_binary": {
         "deps": attrs.list(attrs.dep(providers = [PythonBootstrapSources]), default = []),
         "main": attrs.source(),
-        "copy_deps": attrs.bool(default = False),
+        "copy_deps": attrs.bool(default = True),
         "_exec_os_type": buck.exec_os_type_arg(),
         "_python_bootstrap_toolchain": toolchains_common.python_bootstrap(),
         "_win_python_wrapper": attrs.default_only(


### PR DESCRIPTION
RE execution on windows has problems with symbolic links. This change allows some core prelude logic to use copies instead of symbolic links for some of the default tools, and it exposes the raw python helpers as well, so that we can wrap them with different shell scripts on our end:

- sh_binary takes an additional argument to control whether resources are copied or sym-linked. 
- python_boostrap_binary takes and additional argument to control whether resources are copied or sym-linked.
- win_python_wrapper.bat is exported as artifactory, so that it can be used in copy mode.
- cxx/tools/*.py helpers are exported as artifacts, so that they can be used by other rules outside of the prelude. 